### PR TITLE
chore: wait for stable DOM for react components

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
 /// <reference types="cypress" />
+import { registerCommand } from 'cypress-wait-for-stable-dom';
+registerCommand();
 
 Cypress.Commands.add('loginWithRequest', (nextRoute = '/wp-admin') => {
   let isLoggedIn = false;
@@ -40,7 +42,7 @@ Cypress.Commands.add(
     cy.loginWithRequest(loginRoute);
     cy.clearWelcome();
     if (featured) {
-      cy.wait(1000);
+      cy.waitForStableDOM({ pollInterval: 1000, timeout: 10000 })
       cy.get('button').contains('Featured image').click();
       cy.get('.editor-post-featured-image__toggle').click();
       cy.get('.media-frame').find('.media-menu-item').contains('Media Library').click({

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "eslint-plugin-prettier": "^3.4.0",
     "prettier": "^2.3.2",
     "typescript": "^4.3.5"
+  },
+  "dependencies": {
+    "cypress-wait-for-stable-dom": "^0.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,6 +506,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cypress-wait-for-stable-dom@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/cypress-wait-for-stable-dom/-/cypress-wait-for-stable-dom-0.0.1.tgz#e53d0e799064798a8b2034d6456772e65f6f17eb"
+  integrity sha512-wsV6s0gyqZ3g+aRhVKWeYjawbuy6ttnoyMP1Xa6F0vfkgqfy3s+goqU1ajzUU6Nq/vfK03XamGmbtWlOHUZ69Q==
+
 cypress@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.6.0.tgz#80fe7496cd4165a0fa06e25fc11413dda4544463"


### PR DESCRIPTION
I've added a package that allows us to wait until the DOM is stable.
In the editor from WP since 5.9 it looks like some elements are being lazy-loaded from React, cypress has trouble catching those elements if `get()` is invoked to soon.

The same thing could be achieved using `cy.wait()` with longer times prior it was 1 second but `wait()` is not a best practice.

The `waitForStableDOM` command will poll for DOM changes every 1 second and listen for changes from the `muttationObserver` if no changes are detected on subsequent polls it will move on. If elements are still added to the DOM then it will continue polling until timeout.

From my testing it works better than the `wait()` function and in some cases it can be faster and more reliable.

I tried also intercepting the xhr requests and waiting for them to finish but it does not look like the react components are directly tied to those.

Right know without these changes the tests are failing when new posts are created using the `insertPost` command.